### PR TITLE
Darwin fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,8 @@ __pycache__
 *.pyd
 *.pbd
 *.lib
+*.so
 
 temp_*
+
+.venv

--- a/glcontext/darwin.cpp
+++ b/glcontext/darwin.cpp
@@ -140,7 +140,7 @@ PyMethodDef GLContext_methods[] = {
 
 PyType_Slot GLContext_slots[] = {
     {Py_tp_methods, GLContext_methods},
-    {Py_tp_dealloc, GLContext_dealloc},
+    {Py_tp_dealloc, (void *)GLContext_dealloc},
     {},
 };
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ darwin = Extension(
     name='glcontext.darwin',
     sources=['glcontext/darwin.cpp'],
     extra_compile_args=['-fpermissive', '-Wno-deprecated-declarations'],
-    extra_linker_args=['-framework', 'OpenGL', '-Wno-deprecated'],
+    extra_link_args=['-framework', 'OpenGL', '-Wno-deprecated'],
 )
 
 ext_modules = {


### PR DESCRIPTION
Works for me on darwin after a couple of tweaks

* The extra linker args was not picked up due to incorrect attribute set in the darwin `Extension`
* One instance of `error: cannot initialize a member subobject of type 'void *' with an lvalue of type 'void (GLContext *)`

Test script
```python
import glcontext.darwin as backend

ctx = backend.create_context(mode='standalone')
print(ctx)
print(ctx.load('glGetIntegerv'))
```
Output:
```
$ python test.py 
<darwin.GLContext object at 0x1064bb130>
140734524410901
```
