### PR TITLE
Issues found when testing glcontext with moderngl

### DIFF
--- a/glcontext/__init__.py
+++ b/glcontext/__init__.py
@@ -22,9 +22,9 @@ def default_backend(standalone=False):
     if target == 'linux':
         from glcontext import x11
         mode = 'standalone' if standalone else 'detect'
-        return lambda glversion: wgl.create_context(mode=mode, glversion=glversion)
+        return lambda glversion: x11.create_context(mode=mode, glversion=glversion)
 
     if target == 'darwin':
         from glcontext import darwin
         mode = 'standalone' if standalone else 'detect'
-        return lambda glversion: wgl.create_context(mode=mode)
+        return lambda glversion: darwin.create_context(mode=mode)


### PR DESCRIPTION
* Incorrect backend modules used in `__init__` for darwin and linux
