### PR TITLE
Fix `UnicodeDecodeError` on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     name='glcontext',
     version='2.3.3',
     description='Portable OpenGL Context',
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding='utf-8').read(),
     long_description_content_type='text/markdown',
     url='https://github.com/moderngl/glcontext',
     author='Szabolcs Dombi',


### PR DESCRIPTION
```
Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\User\AppData\Local\Temp\pip-install-lrtarx_p\glcontext\setup.py", line 64, in <module>
        long_description=open('README.md').read(),
      File "V:\python\Lib\encodings\cp1251.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 4846: character maps to <undefined>
```