### PR TITLE
Fix "not loaded" error when specifying a custom DLL

### DIFF
--- a/glcontext/__init__.py
+++ b/glcontext/__init__.py
@@ -58,6 +58,13 @@ def _wgl():
     def create(*args, **kwargs):
         _apply_env_var(kwargs, 'glversion', 'GLCONTEXT_GLVERSION', arg_type=int)
         _apply_env_var(kwargs, 'libgl', 'GLCONTEXT_WIN_LIBGL')
+
+        # make sure libgl is an absolute path
+        if 'libgl' in kwargs:
+            _libgl = kwargs['libgl']
+            if '/' in _libgl or '\\' in _libgl:
+                kwargs['libgl'] = os.path.abspath(_libgl)
+
         kwargs = _strip_kwargs(kwargs, ['glversion', 'mode', 'libgl'])
         return wgl.create_context(**kwargs)
 


### PR DESCRIPTION
This happens because on Python 3.8+ the DLL load path is modified to include
only system directories; not even the directory in which the DLL is located.
See: https://docs.python.org/3/whatsnew/3.8.html#changes-in-the-python-api

Without these changes, it would be impossible to load a DLL file that has
dependencies on other DLL files like that of Mesa, even when the full path is
specified. In this change, the DLL and its dependencies are resolved as
done in ctypes, first system directories and then the directories in which
the DLL file specified exists.
