### PR TITLE
Update CI to use cibuildwheel 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,131 +1,79 @@
-name: publish
+name: Publish
 
 on:
+  push:
+  release:
+    types: [created]
   workflow_dispatch:
 
 jobs:
-
-  sdist:
-    name: sdist
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: setup
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-
-      - name: deps
-        run: python -m pip install -U pip wheel setuptools
-
-      - name: sdist
-        run: python setup.py sdist
-
-      - name: upload
-        uses: actions/upload-artifact@v2
-        with:
-          name: dist
-          path: "dist/*.tar.gz"
-
-  wheel:
-    name: wheel
+  build_wheels:
+    name: Build Wheels on ${{ matrix.os }}-${{ matrix.cibw_archs }}
     runs-on: ${{ matrix.os }}
-
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9']
-        architecture: [x64, x86]
-        exclude:
-          - os: ubuntu-latest
-            architecture: x86
-          - os: macos-latest
-            architecture: x86
-
+        os: [ubuntu-18.04, windows-2019, macos-10.15]
+        cibw_archs: ["auto64"]
+        include:
+          - os: ubuntu-18.04
+            cibw_archs: "aarch64"
+          - os: ubuntu-18.04
+            cibw_archs: "auto32"
+          - os: windows-2019
+            cibw_archs: "auto32"
     steps:
-      - uses: actions/checkout@v2
-
-      - name: setup
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        if: matrix.cibw_archs == 'aarch64'
+        uses: docker/setup-qemu-action@v1
         with:
-          python-version: ${{ matrix.python-version }}
-          architecture: ${{ matrix.architecture }}
+          platforms: arm64
 
-      - name: deps
-        run: python -m pip install -U auditwheel pip wheel setuptools
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.3.1
+        with:
+          output-dir: dist/
+        env:
+          CIBW_ARCHS_MACOS: "x86_64 universal2"
+          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-* pp*
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          CIBW_SKIP: "*-musllinux*"
 
-      - name: wheel
-        run: python setup.py bdist_wheel
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./dist/*.whl
+          name: wheels-${{ runner.os }}-${{ matrix.cibw_archs }}
 
-      - name: auditwheel
-        if: contains(matrix.os, 'ubuntu')
-        run: |
-          mv dist temp
-          python -m auditwheel repair -w dist temp/*-linux_x86_64.whl
+  # Build the source distribution under Linux
+  build_sdist:
+    name: Source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
-      - name: upload
+      - name: Build source distribution
+        run: pipx run build --sdist
+
+      - name: Store artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: dist
-          path: "dist/*.whl"
-
-  aarch64_wheel:
-    strategy:
-      matrix:
-        pyver: [cp36-cp36m, cp37-cp37m, cp38-cp38, cp39-cp39]
-      fail-fast: false
-    runs-on: ubuntu-latest
-    env:
-      py: /opt/python/${{ matrix.pyver }}/bin/python
-      img: quay.io/pypa/manylinux2014_aarch64
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Set up QEMU
-      id: qemu
-      uses: docker/setup-qemu-action@v1
-    - name: Build wheel
-      run: |
-            docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
-            ${{ env.img }} \
-            bash -exc '${{ env.py }} -m venv .env && \
-            source .env/bin/activate && \
-            python -m pip install -U auditwheel pip wheel setuptools && \
-            python setup.py bdist_wheel && \
-            mv dist temp && \
-            python -m auditwheel repair -w dist temp/*-linux_aarch64.whl && \
-            deactivate'
-    - name: upload
-      uses: actions/upload-artifact@v2
-      with:
-        name: dist
-        path: "dist/*.whl"
+          path: dist/*.tar.gz
 
   publish:
     name: publish
     needs:
-      - sdist
-      - wheel
-      - aarch64_wheel
+      - build_sdist
+      - build_wheels
     runs-on: ubuntu-latest
-
+    if: github.event_name== 'release' && github.event.action == 'published'
     steps:
-      - name: setup
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-
-      - name: deps
-        run: python -m pip install -U twine
-
       - name: download
         uses: actions/download-artifact@v2
+        with:
+          path: dist/
 
-      - name: upload
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: python -m twine upload dist/*
-        # run: ls dist/*
+      - uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools >= 40.6.2",
+    "wheel >= 0.30.0",
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
- [Add `pyproject.toml` for PEP-517 build](https://github.com/moderngl/glcontext/commit/d60c87ece6ecacf085c3d027cfc29a6dbc53af5e)
- The CI now uses the [cibuildwheel](http://github.com/pypa/cibuildwheel) for building wheels on various platforms and uploads it as an artefact.
See https://github.com/naveen521kk/glcontext/actions/runs/1951079932 for a test run